### PR TITLE
Redis-based deduplication; performance tweaks

### DIFF
--- a/cdr_dedupe.py
+++ b/cdr_dedupe.py
@@ -1,98 +1,145 @@
+#!/usr/bin/env python
 from __future__ import print_function
 import argparse
 import gzip as gz
 import json
 import hashlib
 import datetime
+import contextlib
 
-def hash_pair(doc):
-    '''
-    Takes in CDR document, hashes the raw content
-    then hashes the url plus the raw content hash
-    '''
-    
-    # gather raw content
+try:
+    import redis
+except ImportError:
+    print("redis is not available")
+    pass
+
+try:
+    from tqdm import tqdm
+except ImportError:
+    tqdm = lambda x: x
+
+
+def get_content_hash(doc):
+    """ Return hash of a raw content """
     raw_content = doc.get('raw_content')
-    
-    # remove leading http(s):// and trailing /
+    return hashlib.sha1(raw_content.encode('utf8')).hexdigest()
+
+
+def get_cleaned_url(doc):
+    """
+    Return a cleaned version of document URL. Currently
+    It removes http(s):// and trailing slash.
+    """
     url = doc.get('url').split("://")[-1]
     if url[-1] == '/':
         url = url[:-1]
-    
-    # take sha1 hash of raw_content
-    try:
-        content_hash = hashlib.sha1(raw_content).hexdigest()
+    return url
 
-    # in case of a unicode encoding error, encode as 'utf-8'
-    except UnicodeEncodeError:
-        content_hash = hashlib.sha1(raw_content.encode('utf-8')).hexdigest()
-    
-    # generate hash using url and content hash
-    hash_pair = hashlib.md5(url+content_hash).hexdigest()
-    
-    return (hash_pair, url, content_hash)
 
-if __name__ == '__main__':
+def get_doc_hash(url, content_hash):
+    """ Return document hash. It is composed from URL and document hash. """
+    h = hashlib.sha1(url.encode('utf8') + content_hash.encode('ascii'))
+    return h.hexdigest()
 
-    desc='CDR Deduplication'
-    parser = argparse.ArgumentParser(
-        description=desc,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=desc)
 
-    parser.add_argument("--input_file", help="path to the gzip file for testing")    
-    parser.add_argument("--result_file", help="path to the deduped output file")    
-    
-    args = parser.parse_args()
+class RedisChecker(object):
+    def __init__(self, redis, namespace='dedupe:'):
+        self.r = redis
+        self.namespace = namespace
 
-    # parsed argument for input/result file
-    input_file = args.input_file
-    result_file = args.result_file
+    def is_new(self, key):
+        """ Return True if key is not seen; add key to seen keys. """
+        return bool(r.setnx(self.namespace + key, 1))
 
-    # generate input _ids dictionary
-    unique_set = set()
 
-    # capture start time
-    start = datetime.datetime.now()
-    input_count = 0
+class InMemoryChecker(object):
+    def __init__(self):
+        self.seen = set()
 
-    # iterate over input file to generate identify uniques
-    with gz.open(input_file,'r') as fp:
-        for line in fp:
-            doc = json.loads(line)
+    def is_new(self, key):
+        if key in self.seen:
+            return False
+        self.seen.add(key)
+        return True
 
-            # ensure the document is a crawl, not media
-            if 'raw_content' in doc: 
 
-                # iterate counter
-                input_count += 1
+def deduplicate(input_path, result_path, dupe_checker):
+    """
+    Iterate over input file, check for duplicates using
+    dupe_checker, write unique lines to the result file.
+    """
+    total_dupes = 0
+
+    with gz.open(input_path, 'rb') as fp:
+        with gz.open(result_path, 'ab', compresslevel=4) as out:
+            for line in tqdm(fp):
+                doc = json.loads(line.decode('utf8'))
+                if 'raw_content' not in doc:
+                    # document is media, not a crawl
+                    continue
 
                 # generate hash objects
-                doc_hash_obj = hash_pair(doc)
-                doc_hash = doc_hash_obj[0]
-                cleaned_url = doc_hash_obj[1]
-                content_hash = doc_hash_obj[2]
+                cleaned_url = get_cleaned_url(doc)
+                content_hash = get_content_hash(doc)
+                doc_hash = get_doc_hash(cleaned_url, content_hash)
 
-                # if not in unique set, add to set and write to file
-                if doc_hash not in unique_set:
-
-                    # add to set
-                    unique_set.add(doc_hash)
-
+                if dupe_checker.is_new(doc_hash):
                     # add hash and cleaned URL to doc
                     doc['content_hash'] = content_hash
                     doc['cleaned_url'] = cleaned_url
 
                     # write output
-                    with gz.open(result_file, 'a') as out:
-                        out.write(json.dumps(doc)+'\n')
-                    out.close()
-        fp.close()
+                    out.write(json.dumps(doc).encode('utf8'))
+                    out.write(b'\n')
+                else:
+                    total_dupes += 1
 
-    deduped_count = len(unique_set)
-    total_dupes = input_count - deduped_count
+    return total_dupes
+
+
+@contextlib.contextmanager
+def log_time():
+    start = datetime.datetime.now()
+    yield
     end = datetime.datetime.now()
     total_time = end - start
-    
-    print(str(total_dupes) + ' duplicates found')
     print('Took ' + str(total_time))
+
+
+if __name__ == '__main__':
+
+    desc = 'CDR Deduplication'
+    parser = argparse.ArgumentParser(
+        description=desc,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=desc)
+
+    parser.add_argument("--input_file",
+                        help="path to the gzip file for testing",
+                        required=True)
+    parser.add_argument("--result_file",
+                        help="path to the deduped output file",
+                        required=True)
+    parser.add_argument("--redis_prefix",
+                        help="Redis key prefix to use for deduplication "
+                             "(a string). When not set, Redis is not used.")
+    parser.add_argument("--redis_host", help="Redis host", default="localhost")
+    parser.add_argument("--redis_port", help="Redis port",
+                        default=6379, type=int)
+    args = parser.parse_args()
+
+    if args.redis_prefix is not None:
+        r = redis.StrictRedis(args.redis_host, args.redis_port)
+        r.ping()
+        namespace = "dedupe:" + args.redis_prefix + ":"
+        dupe_checker = RedisChecker(r, namespace=namespace)
+    else:
+        dupe_checker = InMemoryChecker()
+
+    # parsed argument for input/result file
+    input_file = args.input_file
+    result_file = args.result_file
+
+    with log_time():
+        total_dupes = deduplicate(input_file, result_file, dupe_checker)
+        print(str(total_dupes) + ' duplicates found')

--- a/cdr_dedupe.py
+++ b/cdr_dedupe.py
@@ -30,8 +30,8 @@ def get_cleaned_url(doc):
     Return a cleaned version of document URL. Currently
     It removes http(s):// and trailing slash.
     """
-    url = doc.get('url').split("://")[-1]
-    if url[-1] == '/':
+    url = doc.get('url').strip().split("://", 1)[-1]
+    if url[-1:] == '/':
         url = url[:-1]
     return url
 


### PR DESCRIPTION
We have many .jl.gz files on several machines and want to process them in parallel. A simple tweak to the script allows to do that: instead of checking if a hash is in a Python set there is now an option to check if it is in Redis instance.
- optional redis-based deduplication. It can be used to deduplicate files in parallel.
- sha1 hash is taken everywhere (it is not slower than md5);
- optional progress indication support;
- output file is opened once. This allows to run faster (~2x), but it means that's more likely to get a broken .gz archive if deduplication is stopped using Ctrl-C. It was possible to get a broken file previously too, but it was less likely.
- Python 3 support (works in 2.x too)
- A couple issues with URL cleaning is fixed (thanks @lopuhin for the catch)

By default the script should do almost the same as a version in master (i.e. redis is not required), but run faster and be less tolerant to Ctrl-C. 
