### PR TITLE
Memex domains

### DIFF
--- a/memex-domains/README.md
+++ b/memex-domains/README.md
@@ -2,7 +2,7 @@ To install the `memex-domains` index template:
 
     curl -XPUT -u username:password --data @template.json https://cdr-es.istresearch.com:9200/_template/memex-domains
 
-Creation of a new monthly index is handled by `crontab` and `monthly_index.sh`. To manually create a new
+Creation of a new monthly index and updating aliases is handled by `crontab` and `monthly_index.sh`. To manually create a new
 `memex-domains_YYYY.MM` monthly index:
 
     curl -XPUT -u username:password https://cdr-es.istresearch.com:9200/memex-domains_YYYY.MM

--- a/memex-domains/README.md
+++ b/memex-domains/README.md
@@ -1,0 +1,18 @@
+To install the `memex-domains` index template:
+
+    curl -XPUT -u username:password --data @template.json https://cdr-es.istresearch.com:9200/_template/memex-domains
+
+Creation of a new monthly index is handled by `crontab` and `monthly_index.sh`. To manually create a new
+`memex-domains_YYYY.MM` monthly index:
+
+    curl -XPUT -u username:password https://cdr-es.istresearch.com:9200/memex-domains_YYYY.MM
+
+To switch the `memex-domains_current` alias from `memex-domains_YYYY.M0` to `memex-domains_YYYY.M1`:
+
+    curl -XPOST -u username:password https://cdr-es.istresearch.com:9200/_aliases -d '
+    {
+        "actions" : [
+            { "remove" : { "index" : "memex-domains_YYYY.M0", "alias" : "memex-domains_current" } },
+            { "add" : { "index" : "memex-domains_YYYY.M1", "alias" : "memex-domains_current" } }
+        ]
+    }'

--- a/memex-domains/crontab
+++ b/memex-domains/crontab
@@ -1,0 +1,11 @@
+# /etc/crontab: system-wide crontab
+
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+PATH_TO_SCRIPT=/
+USER=cdr-memex
+PASSWORD=s7Zhd71r3VD8ojRj
+
+# m h dom mon dow user	command
+00 0    1 * *   root    $PATH_TO_SCRIPT/monthly_index $USER $PASSWORD
+#

--- a/memex-domains/monthly_index.sh
+++ b/memex-domains/monthly_index.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Get command line arguments
+if [ $# -lt 2 ]
+then
+    echo "Not enought arguments given!"
+    echo "monthly_index USER PASSWORD"
+    exit 1
+fi
+
+# Get the current date
+curr_date=`date +%Y.%m`
+prev_date=`date -d "-2 days" +%Y.%m`
+# Create a new index
+curl -XPUT "https://$1:$2@cdr-es.istresearch.com:9200/memex-domains_$curr_date"
+# Update aliases
+curl -XPOST "https://$1:$2@cdr-es.istresearch.com:9200/_aliases" -d "{
+    \"actions\" : [
+        { \"add\" : { \"index\" : \"memex-domains_$curr_date\", \"alias\" : \"memex-domains_current\" } },
+        { \"remove\" : { \"index\" : \"memex-domains_$prev_date\", \"alias\" : \"memex-domains_current\" } },
+        { \"add\" : { \"index\" : \"memex-domains_$curr_date\", \"alias\" : \"memex-domains\" } }
+    ]
+}"

--- a/memex-domains/template.json
+++ b/memex-domains/template.json
@@ -2,6 +2,8 @@
     "order": 1,
     "template": "memex-domains_*",
     "settings": {
+      "number_of_shards" : 10,
+      "number_of_replicas" : 1,
       "index.analysis.filter.capture_hostname_filter.preserve_original": "false",
       "index.analysis.analyzer.hostname_analyzer.tokenizer": "keyword",
       "index.analysis.filter.capture_hostname_filter.type": "pattern_capture",
@@ -31,7 +33,7 @@
               "match_mapping_type": "string"
             }
           },
-          { 
+          {
             "extracted_metadata": {
               "path_match": "extracted_metadata.*",
               "mapping": {
@@ -39,7 +41,7 @@
               }
             }
           },
-          { 
+          {
             "extracted_metadata_children": {
               "path_match": "extracted_metadata.*.*",
               "mapping": {
@@ -1210,7 +1212,7 @@
     },
     "aliases": {
       "memex-domains": {
-        
+
       }
     }
 }

--- a/memex-domains/template.json
+++ b/memex-domains/template.json
@@ -1,0 +1,1216 @@
+{
+    "order": 1,
+    "template": "memex-domains_*",
+    "settings": {
+      "index.analysis.filter.capture_hostname_filter.preserve_original": "false",
+      "index.analysis.analyzer.hostname_analyzer.tokenizer": "keyword",
+      "index.analysis.filter.capture_hostname_filter.type": "pattern_capture",
+      "index.analysis.filter.hostname_to_domain_filter.flags": "CASE_INSENSITIVE",
+      "index.analysis.filter.capture_hostname_filter.patterns.0": "https?:\/\/([^:\/]+)",
+      "index.analysis.analyzer.domain_analyzer.type": "custom",
+      "index.analysis.filter.capture_hostname_filter.flags": "CASE_INSENSITIVE",
+      "index.analysis.analyzer.domain_analyzer.filter.1": "hostname_to_domain_filter",
+      "index.analysis.analyzer.domain_analyzer.filter.0": "capture_hostname_filter",
+      "index.analysis.filter.hostname_to_domain_filter.patterns.0": "([a-z0-9\\-]+(?:\\.[a-z0-9\\-]{2,3}){1,2})$",
+      "index.analysis.analyzer.hostname_analyzer.type": "custom",
+      "index.analysis.analyzer.hostname_analyzer.filter.0": "capture_hostname_filter",
+      "index.analysis.filter.hostname_to_domain_filter.type": "pattern_capture",
+      "index.analysis.filter.hostname_to_domain_filter.preserve_original": "false",
+      "index.analysis.analyzer.domain_analyzer.tokenizer": "keyword"
+    },
+    "mappings": {
+      "_default_": {
+        "dynamic_templates": [
+          {
+            "string_fields": {
+              "mapping": {
+                "analyzer": "standard",
+                "type": "string"
+              },
+              "match": "*",
+              "match_mapping_type": "string"
+            }
+          },
+          { 
+            "extracted_metadata": {
+              "path_match": "extracted_metadata.*",
+              "mapping": {
+                "type": "string"
+              }
+            }
+          },
+          { 
+            "extracted_metadata_children": {
+              "path_match": "extracted_metadata.*.*",
+              "mapping": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "autonomy": {
+        "_all": {
+          "enabled": false
+        },
+        "_timestamp": {
+          "enabled": true
+        },
+        "properties": {
+          "obj_parent": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "version": {
+            "type": "float"
+          },
+          "crawl_data": {
+            "type": "object"
+          },
+          "crawler": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "team": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "timestamp": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "raw_content": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "content_type": {
+            "type": "multi_field",
+            "fields": {
+              "content_type": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              }
+            }
+          },
+          "url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "extracted_text": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "extracted_metadata": {
+            "type": "object"
+          },
+          "obj_original_url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "obj_stored_url": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "annotation1": {
+            "type": "short"
+          },
+          "annotation2": {
+            "type": "short"
+          },
+          "adjudication": {
+            "type": "short"
+          }
+        }
+      },
+      "trolls": {
+        "_all": {
+          "enabled": false
+        },
+        "_timestamp": {
+          "enabled": true
+        },
+        "properties": {
+          "obj_parent": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "crawl_data": {
+            "type": "object"
+          },
+          "crawler": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "team": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "timestamp": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "raw_content": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "content_type": {
+            "type": "multi_field",
+            "fields": {
+              "content_type": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              }
+            }
+          },
+          "url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "extracted_text": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "extracted_metadata": {
+            "type": "object"
+          },
+          "obj_original_url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "obj_stored_url": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "annotation1": {
+            "type": "short"
+          },
+          "annotation2": {
+            "type": "short"
+          },
+          "adjudication": {
+            "type": "short"
+          }
+        }
+      },
+      "microcap": {
+        "_all": {
+          "enabled": false
+        },
+        "_timestamp": {
+          "enabled": true
+        },
+        "properties": {
+          "obj_parent": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "crawl_data": {
+            "type": "object"
+          },
+          "crawler": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "team": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "timestamp": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "raw_content": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "content_type": {
+            "type": "multi_field",
+            "fields": {
+              "content_type": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              }
+            }
+          },
+          "url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "extracted_text": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "extracted_metadata": {
+            "type": "object"
+          },
+          "obj_original_url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "obj_stored_url": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "annotation1": {
+            "type": "short"
+          },
+          "annotation2": {
+            "type": "short"
+          },
+          "adjudication": {
+            "type": "short"
+          }
+        }
+      },
+      "escorts": {
+        "_all": {
+          "enabled": false
+        },
+        "_timestamp": {
+          "enabled": true
+        },
+        "properties": {
+          "obj_parent": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "crawl_data": {
+            "type": "object"
+          },
+          "crawler": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "team": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "timestamp": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "raw_content": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "content_type": {
+            "type": "multi_field",
+            "fields": {
+              "content_type": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              }
+            }
+          },
+          "url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "extracted_text": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "extracted_metadata": {
+            "type": "object"
+          },
+          "obj_original_url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "obj_stored_url": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "annotation1": {
+            "type": "short"
+          },
+          "annotation2": {
+            "type": "short"
+          },
+          "adjudication": {
+            "type": "short"
+          }
+        }
+      },
+      "labor": {
+        "_all": {
+          "enabled": false
+        },
+        "_timestamp": {
+          "enabled": true
+        },
+        "properties": {
+          "obj_parent": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "crawl_data": {
+            "type": "object"
+          },
+          "crawler": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "team": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "timestamp": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "raw_content": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "content_type": {
+            "type": "multi_field",
+            "fields": {
+              "content_type": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              }
+            }
+          },
+          "url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "extracted_text": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "extracted_metadata": {
+            "type": "object"
+          },
+          "obj_original_url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "obj_stored_url": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "annotation1": {
+            "type": "short"
+          },
+          "annotation2": {
+            "type": "short"
+          },
+          "adjudication": {
+            "type": "short"
+          }
+        }
+      },
+      "persona": {
+        "_all": {
+          "enabled": false
+        },
+        "_timestamp": {
+          "enabled": true
+        },
+        "properties": {
+          "obj_parent": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "crawl_data": {
+            "type": "object"
+          },
+          "crawler": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "team": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "timestamp": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "raw_content": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "content_type": {
+            "type": "multi_field",
+            "fields": {
+              "content_type": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              }
+            }
+          },
+          "url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "extracted_text": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "extracted_metadata": {
+            "type": "object"
+          },
+          "obj_original_url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "obj_stored_url": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "annotation1": {
+            "type": "short"
+          },
+          "annotation2": {
+            "type": "short"
+          },
+          "adjudication": {
+            "type": "short"
+          }
+        }
+      },
+      "qcr": {
+        "_all": {
+          "enabled": false
+        },
+        "_timestamp": {
+          "enabled": true
+        },
+        "properties": {
+          "obj_parent": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "crawl_data": {
+            "type": "object"
+          },
+          "crawler": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "team": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "timestamp": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "raw_content": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "content_type": {
+            "type": "multi_field",
+            "fields": {
+              "content_type": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              }
+            }
+          },
+          "url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "extracted_text": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "extracted_metadata": {
+            "type": "object"
+          },
+          "obj_original_url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "obj_stored_url": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "annotation1": {
+            "type": "short"
+          },
+          "annotation2": {
+            "type": "short"
+          },
+          "adjudication": {
+            "type": "short"
+          }
+        }
+      },
+      "electronics": {
+        "_all": {
+          "enabled": false
+        },
+        "_timestamp": {
+          "enabled": true
+        },
+        "properties": {
+          "obj_parent": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "crawl_data": {
+            "type": "object"
+          },
+          "crawler": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "team": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "timestamp": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "raw_content": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "content_type": {
+            "type": "multi_field",
+            "fields": {
+              "content_type": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              }
+            }
+          },
+          "url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "extracted_text": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "extracted_metadata": {
+            "type": "object"
+          },
+          "obj_original_url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "obj_stored_url": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "annotation1": {
+            "type": "short"
+          },
+          "annotation2": {
+            "type": "short"
+          },
+          "adjudication": {
+            "type": "short"
+          }
+        }
+      },
+      "pyramid": {
+        "_all": {
+          "enabled": false
+        },
+        "_timestamp": {
+          "enabled": true
+        },
+        "properties": {
+          "obj_parent": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "crawl_data": {
+            "type": "object"
+          },
+          "crawler": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "team": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "timestamp": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "raw_content": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "content_type": {
+            "type": "multi_field",
+            "fields": {
+              "content_type": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              }
+            }
+          },
+          "url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "extracted_text": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "extracted_metadata": {
+            "type": "object"
+          },
+          "obj_original_url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "obj_stored_url": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "annotation1": {
+            "type": "short"
+          },
+          "annotation2": {
+            "type": "short"
+          },
+          "adjudication": {
+            "type": "short"
+          }
+        }
+      },
+      "weapons": {
+        "_all": {
+          "enabled": false
+        },
+        "_timestamp": {
+          "enabled": true
+        },
+        "properties": {
+          "obj_parent": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "crawl_data": {
+            "type": "object"
+          },
+          "crawler": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "team": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "timestamp": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "raw_content": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "content_type": {
+            "type": "multi_field",
+            "fields": {
+              "content_type": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              }
+            }
+          },
+          "url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "extracted_text": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "extracted_metadata": {
+            "type": "object"
+          },
+          "obj_original_url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "obj_stored_url": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "annotation1": {
+            "type": "short"
+          },
+          "annotation2": {
+            "type": "short"
+          },
+          "adjudication": {
+            "type": "short"
+          }
+        }
+      },
+      "other": {
+        "_all": {
+          "enabled": false
+        },
+        "_timestamp": {
+          "enabled": true
+        },
+        "properties": {
+          "obj_parent": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "crawl_data": {
+            "type": "object"
+          },
+          "crawler": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "team": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "timestamp": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "raw_content": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "content_type": {
+            "type": "multi_field",
+            "fields": {
+              "content_type": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              }
+            }
+          },
+          "url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "extracted_text": {
+            "analyzer": "standard",
+            "type": "string"
+          },
+          "extracted_metadata": {
+            "type": "object"
+          },
+          "obj_original_url": {
+            "type": "multi_field",
+            "fields": {
+              "url": {
+                "type": "string"
+              },
+              "exact": {
+                "type": "string",
+                "analyzer": "keyword"
+              },
+              "hostname": {
+                "type": "string",
+                "analyzer": "hostname_analyzer"
+              },
+              "domain": {
+                "type": "string",
+                "analyzer": "domain_analyzer"
+              }
+            }
+          },
+          "obj_stored_url": {
+            "type": "string",
+            "analyzer": "keyword"
+          },
+          "annotation1": {
+            "type": "short"
+          },
+          "annotation2": {
+            "type": "short"
+          },
+          "adjudication": {
+            "type": "short"
+          }
+        }
+      }
+    },
+    "aliases": {
+      "memex-domains": {
+        
+      }
+    }
+}


### PR DESCRIPTION
This branch includes the directory memex-domains which contains the template used for index creation in the CDR as well as the crontab and shell script to automatically create a new monthly index and update aliases.  Included in the template is a fix for domains like `co.uk` or `com.au`, so they will instead look like  `craigslist.co.uk`, `vivastreet.com.au`, `anunico.co.in`, etc.
